### PR TITLE
Use PropTypes as separated package

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "peerDependencies": {
     "react": ">=15.2.0",
-    "react-native": ">=0.29.0"
+    "react-native": ">=0.29.0",
+    "prop-types": "^15.5.10"
   },
   "repository": {
     "type": "git",

--- a/src/after-interactions.js
+++ b/src/after-interactions.js
@@ -1,4 +1,5 @@
-import {Component, PropTypes} from 'react';
+import {Component} from 'react';
+import PropTypes from 'prop-types';
 import {InteractionManager} from 'react-native';
 
 export default class AfterInteractions extends Component {


### PR DESCRIPTION
This change prevents warning by the React.PropTypes depreciation